### PR TITLE
Automate creation of genesis.json

### DIFF
--- a/gather.sh
+++ b/gather.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+dir=~/.celestia-app/config/gentx
+
+if [ "$1" != "" ]; then
+	dir=$1
+fi
+
+echo "Adding genesis accounts from files located in: $dir"
+for f in `ls $dir/gentx*.json`;
+do 
+	echo $f
+	addr=`cat $f | jq '.body.messages[] | .delegator_address' | tr -d \"`
+	amount=`cat $f | jq '.body.messages[] | .value.amount' | tr -d \"`
+	denom=`cat $f | jq '.body.messages[] | .value.denom' | tr -d \"`
+	celestia-appd add-genesis-account $addr "$amount$denom"
+done


### PR DESCRIPTION
This script can extract information about validator allocation from
gentx-*.json files and add it to genesis.json using add-genesis-account

So we can just accept gentx-*.json files, and avoid merging genesis.json
by hand.