### PR TITLE
Cosmetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ celestia-appd add-genesis-account $O_acc_addr 800000000000celes
 <b><u>Note: Currently, we've found an issue that `genesis.json` is using `stake` instead of `celes` token [#158](https://github.com/celestiaorg/celestia-app/issues/158)</u></b>
 <b>Please, either manually change `stake` to `celes` in `genesis.json` or execute this script:</b>
 ```sh
-sudo apt-get install moreutils jq #contains sponge that we need
+sudo apt install moreutils jq #contains sponge that we need
 cd networks/scripts
 ./fix_genesis.sh ~/.celestia-app/config/genesis.json
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ celestia-appd add-genesis-account $O_acc_addr 800000000000celes
 <b><u>Note: Currently, we've found an issue that `genesis.json` is using `stake` instead of `celes` token [#158](https://github.com/celestiaorg/celestia-app/issues/158)</u></b>
 <b>Please, either manually change `stake` to `celes` in `genesis.json` or execute this script:</b>
 ```sh
-sudo apt-get install moreutils #contains sponge that we need
+sudo apt-get install moreutils jq #contains sponge that we need
 cd networks/scripts
 ./fix_genesis.sh ~/.celestia-app/config/genesis.json
 ```

--- a/scripts/fix_genesis.sh
+++ b/scripts/fix_genesis.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 if [ "$1" == "--help" ] ; then
     echo "Usage: ./fix_genesis.sh path/to/genesis.json new_token_name"
     exit 0

--- a/scripts/fix_genesis.sh
+++ b/scripts/fix_genesis.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 set -e
-if [ "$1" == "--help" ] ; then
+if ([ "$1" == "--help" ] || [ -z "$2" ]); then
     echo "Usage: ./fix_genesis.sh path/to/genesis.json new_token_name"
     exit 0
 fi
+
 
 # $1 -> path to genesis.json
 # $2 -> becomes an token arg in jq 

--- a/scripts/fix_genesis.sh
+++ b/scripts/fix_genesis.sh
@@ -6,7 +6,6 @@ if ([ "$1" == "--help" ] || [ -z "$2" ]); then
     exit 0
 fi
 
-
 # $1 -> path to genesis.json
 # $2 -> becomes an token arg in jq 
 cat $1 | jq --arg token $2 '.app_state.crisis.constant_fee.denom = $token' | sponge $1

--- a/scripts/fix_genesis.sh
+++ b/scripts/fix_genesis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-if ([ "$1" == "--help" ] || [ -z "$2" ]); then
+if [ "$1" == "--help" ] || [ -z "$2" ]; then
     echo "Usage: ./fix_genesis.sh path/to/genesis.json new_token_name"
     exit 0
 fi


### PR DESCRIPTION
- Adds `set -e` for the `fix_genesis.sh` script  to exit if a command fails. This ensures not executing the rest of the script and have unwanted behavior.
- Adds `jq` to the list of dependencies needed as it doesn't come by default in distributions.
- Adds an extra condition to `fix_genesis.sh` to print the `usage` when the second argument is not passed.