### PR TITLE
Specify the right commit for celestia-app to join devnet-2

### DIFF
--- a/celestia-application.md
+++ b/celestia-application.md
@@ -52,6 +52,7 @@ cd $HOME
 rm -rf celestia-app
 git clone https://github.com/celestiaorg/celestia-app.git
 cd celestia-app/
+git checkout 2015a0cac19c841d5971c1155c53fa2b9f736d6b
 make install
 ```
 To check if the binary was succesfully compiled you can run the binary using the `--help` flag:


### PR DESCRIPTION
Currently, the latest master of `Celestia-App` is not compatible with the version we have running for devnet-2. Thus, we need to checkout a previous version to successfully join it.
This PR adds reference to that commit in the intructions.