### PR TITLE
docs: README networks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ your own node [here](https://docs.celestia.org)
 
 ## Networks
 
-Network | celestia-app | celestia-node
---- | --- | ---
-Arabica | [v0.10.0-rc1](https://github.com/celestiaorg/celestia-app/releases/tag/v0.10.0-rc1) | [v0.5.0-rc5](https://github.com/celestiaorg/celestia-node/releases/tag/v0.5.0-rc5)
+| Network | celestia-node                                                                      | celestia-app                                                                        | celestia-core                                                                                      | cosmos-sdk                                                                                      |
+| ------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Arabica | [v0.5.0-rc5](https://github.com/celestiaorg/celestia-node/releases/tag/v0.5.0-rc5) | [v0.10.0-rc1](https://github.com/celestiaorg/celestia-app/releases/tag/v0.10.0-rc1) | [v1.5.0-tm-v0.34.20](https://github.com/celestiaorg/celestia-core/releases/tag/v1.5.0-tm-v0.34.20) | [v1.4.0-sdk-v0.46.0](https://github.com/celestiaorg/cosmos-sdk/releases/tag/v1.4.0-sdk-v0.46.0) |

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ This repository contains the `genesis.json` for Celestia testnets.
 
 Please refer to the Celestia Docs for guides on getting started running
 your own node [here](https://docs.celestia.org)
+
+## Networks
+
+Network | celestia-app | celestia-node
+--- | --- | ---
+Arabica | [v0.10.0-rc1](https://github.com/celestiaorg/celestia-app/releases/tag/v0.10.0-rc1) | [v0.5.0-rc5](https://github.com/celestiaorg/celestia-node/releases/tag/v0.5.0-rc5)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/networks/issues/159

## Motivation
I'm not sure where the source of truth is for the version(s) of software that are running on our networks. This repo seems like a good candidate for such a table. I'm concerned this table won't be updated when software on our networks is updated so please comment if there's a better repo for such a table.