### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -37,15 +37,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.COMMIT_CSV_UPDATE }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
       - name: Check user csv
         id: check-user-pr
         run: go run .github/workflows/checkuser.go ${{github.actor}} ${{github.event.number}}
-      - name: Commit changes to the csv
-        if: success()
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: "Add ${{github.actor}} with pr ${{github.event.number}} to usersprs.csv file"
       - name: Add comment about user in csv
         if: failure()
         uses: actions/github-script@v6
@@ -58,6 +58,11 @@ jobs:
               repo: context.repo.repo,
               body: 'User has previously submitted a gentx PR'
             })
+      - name: Commit changes to the csv
+        if: success()
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Add ${{github.actor}} with pr ${{github.event.number}} to usersprs.csv file"
 
   jq-format:
     needs: find-gentx-files

--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -29,8 +29,8 @@ jobs:
     if: needs.find-gentx-files.outputs.gentx-changed == 'true'
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
+        # with:
+        # ref: ${{ github.event.pull_request.head.ref }}
       - name: Check user csv
         id: check-user-pr
         run: go run .github/workflows/checkuser.go ${{github.actor}} ${{github.event.number}}

--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -1,6 +1,13 @@
 name: Validate Gentx
 on:
-  pull_request:
+  # Using pull_request_target to allow forks to write comments and update the
+  # csv file that is tracking the authors.
+  # This is OK because of the branch protections we have on the repo so forks
+  # can't change anything without their PR being approved.
+  #
+  # NOTE: This means we should be careful when extending this specific workflow
+  # file.
+  pull_request_target:
 
 jobs:
   find-gentx-files:

--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -36,8 +36,8 @@ jobs:
     if: needs.find-gentx-files.outputs.gentx-changed == 'true'
     steps:
       - uses: actions/checkout@v4
-        # with:
-        # ref: ${{ github.event.pull_request.head.ref }}
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Check user csv
         id: check-user-pr
         run: go run .github/workflows/checkuser.go ${{github.actor}} ${{github.event.number}}


### PR DESCRIPTION
# Overview

There were 3 main errors in the CI:
1. Checkouts were failing
2. Comments on PRs were failing
3. Writes to the CSV where failling

They all were related to fork related permission issues. 

First CI fix was using the `pull_request_target` trigger to give the workflow the right level of permissions to make the comments and checkout the users code.

The Second CI fix was to add a PAT for the checkout and the updating of the csv. This PAT is set to expire in 30 days for safety since this particular CI of updating the csv won't be needed post launch.

Testing was done on this repo: https://github.com/celestiaorg/networks-temp
Test scenarios included:
- PR from repo branch
- PR from fork branch
- PR from fork branch that was not a member of celestia

**NOTE** because this PR is changing the trigger, it won't run that CI on this PR. Once merged into master the CI will be triggered again so other PRs will need to be updated. 

closes remaining tasks in: https://github.com/celestiaorg/networks/issues/366
