### PR TITLE
feat: celestia addrbook.json

### DIFF
--- a/celestia/addrbook.json
+++ b/celestia/addrbook.json
@@ -1,0 +1,1385 @@
+{
+	"key": "17227af1d5a8438d13669adb",
+	"addrs": [
+		{
+			"addr": {
+				"id": "1d824f2cf4df9c9da98c120b78be3f4319a1d7ff",
+				"ip": "46.4.23.42",
+				"port": 26656
+			},
+			"src": {
+				"id": "1d824f2cf4df9c9da98c120b78be3f4319a1d7ff",
+				"ip": "46.4.23.42",
+				"port": 26656
+			},
+			"buckets": [
+				62
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674034+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "1d607e1859212eb8cd4130a1df074d201fb5186c",
+				"ip": "168.119.64.26",
+				"port": 26656
+			},
+			"src": {
+				"id": "1d607e1859212eb8cd4130a1df074d201fb5186c",
+				"ip": "168.119.64.26",
+				"port": 26656
+			},
+			"buckets": [
+				169
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675477+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "76455257d6ae848d17b6e324b1b278c01f4b769d",
+				"ip": "23.175.49.74",
+				"port": 34656
+			},
+			"src": {
+				"id": "76455257d6ae848d17b6e324b1b278c01f4b769d",
+				"ip": "23.175.49.74",
+				"port": 34656
+			},
+			"buckets": [
+				169
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:54.073981+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "e92c1f9c189018d4b94899f99ee24d0b90f6b9b5",
+				"ip": "217.160.39.214",
+				"port": 26656
+			},
+			"src": {
+				"id": "e92c1f9c189018d4b94899f99ee24d0b90f6b9b5",
+				"ip": "217.160.39.214",
+				"port": 26656
+			},
+			"buckets": [
+				180
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671263+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "29c8a82a0be59a2c6a5d6fb2ad0a2e1b4d09de0f",
+				"ip": "181.188.232.25",
+				"port": 26656
+			},
+			"src": {
+				"id": "29c8a82a0be59a2c6a5d6fb2ad0a2e1b4d09de0f",
+				"ip": "181.188.232.25",
+				"port": 26656
+			},
+			"buckets": [
+				123
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674024+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "72dd61ecab64873e45c77f902fec73069dfb33f0",
+				"ip": "103.219.171.65",
+				"port": 26656
+			},
+			"src": {
+				"id": "72dd61ecab64873e45c77f902fec73069dfb33f0",
+				"ip": "103.219.171.65",
+				"port": 26656
+			},
+			"buckets": [
+				213
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674027+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "ce2873ef3893f0da50eb27892761e9c06e704944",
+				"ip": "159.203.143.94",
+				"port": 26656
+			},
+			"src": {
+				"id": "ce2873ef3893f0da50eb27892761e9c06e704944",
+				"ip": "159.203.143.94",
+				"port": 26656
+			},
+			"buckets": [
+				211
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674141+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "acca7837e4eb5f9dc7f5a94ed1d82edda6931ff8",
+				"ip": "5.199.172.51",
+				"port": 26656
+			},
+			"src": {
+				"id": "acca7837e4eb5f9dc7f5a94ed1d82edda6931ff8",
+				"ip": "5.199.172.51",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674833+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "7d5767dfe229d6b82246165c1c353a56a6da1983",
+				"ip": "54.177.201.19",
+				"port": 26656
+			},
+			"src": {
+				"id": "7d5767dfe229d6b82246165c1c353a56a6da1983",
+				"ip": "54.177.201.19",
+				"port": 26656
+			},
+			"buckets": [
+				99
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.67118+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "491c37d5de210600463c5599a3ffd272c8690014",
+				"ip": "57.128.20.184",
+				"port": 23656
+			},
+			"src": {
+				"id": "491c37d5de210600463c5599a3ffd272c8690014",
+				"ip": "57.128.20.184",
+				"port": 23656
+			},
+			"buckets": [
+				159
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671244+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "d364357f55e37a038d9dbd143448ea792bb8edcf",
+				"ip": "15.235.115.156",
+				"port": 16400
+			},
+			"src": {
+				"id": "d364357f55e37a038d9dbd143448ea792bb8edcf",
+				"ip": "15.235.115.156",
+				"port": 16400
+			},
+			"buckets": [
+				137
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671259+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "58e2c4d930c235aeee1e5bd4b906aa373f0ad4f5",
+				"ip": "65.21.232.33",
+				"port": 2000
+			},
+			"src": {
+				"id": "58e2c4d930c235aeee1e5bd4b906aa373f0ad4f5",
+				"ip": "65.21.232.33",
+				"port": 2000
+			},
+			"buckets": [
+				179
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958633+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "a86cfe5a22e73ff0c9ceec388e9b52bf8355efdd",
+				"ip": "85.239.233.57",
+				"port": 2000
+			},
+			"src": {
+				"id": "a86cfe5a22e73ff0c9ceec388e9b52bf8355efdd",
+				"ip": "85.239.233.57",
+				"port": 2000
+			},
+			"buckets": [
+				144
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.95864+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "3b11e4123a9db23f72fb5828b3f5b101217ee43d",
+				"ip": "116.202.208.214",
+				"port": 2600
+			},
+			"src": {
+				"id": "3b11e4123a9db23f72fb5828b3f5b101217ee43d",
+				"ip": "116.202.208.214",
+				"port": 2600
+			},
+			"buckets": [
+				34
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674123+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "95c00bb9f24e907891e9a98c4ad506af093a7944",
+				"ip": "87.106.237.243",
+				"port": 26656
+			},
+			"src": {
+				"id": "95c00bb9f24e907891e9a98c4ad506af093a7944",
+				"ip": "87.106.237.243",
+				"port": 26656
+			},
+			"buckets": [
+				98
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674135+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "ea9d858371ba86ae8f9c5b292c105329029c9efd",
+				"ip": "5.199.174.19",
+				"port": 26656
+			},
+			"src": {
+				"id": "ea9d858371ba86ae8f9c5b292c105329029c9efd",
+				"ip": "5.199.174.19",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674145+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "0cb62ebbce54e2d5e72ced753a879d3c08c61583",
+				"ip": "162.19.171.80",
+				"port": 26656
+			},
+			"src": {
+				"id": "0cb62ebbce54e2d5e72ced753a879d3c08c61583",
+				"ip": "162.19.171.80",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671232+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "7f067f54987cccfe489fbe302ff1bf6c56aaf02f",
+				"ip": "162.19.81.54",
+				"port": 23656
+			},
+			"src": {
+				"id": "7f067f54987cccfe489fbe302ff1bf6c56aaf02f",
+				"ip": "162.19.81.54",
+				"port": 23656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671246+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "5992372287bbb173bd291e299a26495057310165",
+				"ip": "57.128.74.73",
+				"port": 26656
+			},
+			"src": {
+				"id": "5992372287bbb173bd291e299a26495057310165",
+				"ip": "57.128.74.73",
+				"port": 26656
+			},
+			"buckets": [
+				159
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674022+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "0015a3241645e7029804f5e363cdc1822eb0797b",
+				"ip": "57.129.31.8",
+				"port": 26656
+			},
+			"src": {
+				"id": "0015a3241645e7029804f5e363cdc1822eb0797b",
+				"ip": "57.129.31.8",
+				"port": 26656
+			},
+			"buckets": [
+				230
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.78681+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "b1187a51400cef8b49a8482088eac57327989fe8",
+				"ip": "135.181.75.114",
+				"port": 26656
+			},
+			"src": {
+				"id": "b1187a51400cef8b49a8482088eac57327989fe8",
+				"ip": "135.181.75.114",
+				"port": 26656
+			},
+			"buckets": [
+				183
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674038+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "4ad28c8a0b04bac4aac441b105c815c449e2182f",
+				"ip": "65.108.61.189",
+				"port": 26656
+			},
+			"src": {
+				"id": "4ad28c8a0b04bac4aac441b105c815c449e2182f",
+				"ip": "65.108.61.189",
+				"port": 26656
+			},
+			"buckets": [
+				62
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674137+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "9a82b9bc0ab0f15692952aa829c8ba7d2f55315f",
+				"ip": "78.46.93.125",
+				"port": 26666
+			},
+			"src": {
+				"id": "9a82b9bc0ab0f15692952aa829c8ba7d2f55315f",
+				"ip": "78.46.93.125",
+				"port": 26666
+			},
+			"buckets": [
+				244
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675447+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "a623f039a36391662a3b514d1fa17fbaa2e25319",
+				"ip": "149.50.96.24",
+				"port": 16656
+			},
+			"src": {
+				"id": "a623f039a36391662a3b514d1fa17fbaa2e25319",
+				"ip": "149.50.96.24",
+				"port": 16656
+			},
+			"buckets": [
+				241
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671178+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "0cca24be2f0d845e67a3135fb67dff6e71750e60",
+				"ip": "148.251.151.51",
+				"port": 16400
+			},
+			"src": {
+				"id": "0cca24be2f0d845e67a3135fb67dff6e71750e60",
+				"ip": "148.251.151.51",
+				"port": 16400
+			},
+			"buckets": [
+				223
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671251+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "dd603ca5470c0f195dea38d1f938b9e43a729a47",
+				"ip": "162.19.170.154",
+				"port": 26656
+			},
+			"src": {
+				"id": "dd603ca5470c0f195dea38d1f938b9e43a729a47",
+				"ip": "162.19.170.154",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671234+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "4ebfc1fac7a646105956ee563ea0d760e3099269",
+				"ip": "138.201.63.38",
+				"port": 26756
+			},
+			"src": {
+				"id": "4ebfc1fac7a646105956ee563ea0d760e3099269",
+				"ip": "138.201.63.38",
+				"port": 26756
+			},
+			"buckets": [
+				213
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.673344+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "00133e62873e724700421d41d4f2f6d24b849bf4",
+				"ip": "185.111.159.231",
+				"port": 2000
+			},
+			"src": {
+				"id": "00133e62873e724700421d41d4f2f6d24b849bf4",
+				"ip": "185.111.159.231",
+				"port": 2000
+			},
+			"buckets": [
+				179
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958626+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "45779d388b18ad48d98c6ad54f35e95fe2a3b35a",
+				"ip": "165.22.30.175",
+				"port": 26656
+			},
+			"src": {
+				"id": "45779d388b18ad48d98c6ad54f35e95fe2a3b35a",
+				"ip": "165.22.30.175",
+				"port": 26656
+			},
+			"buckets": [
+				76
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671265+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "4ebe56795fc5da1c0dc5f7acd5760d5c8fd4d250",
+				"ip": "5.9.87.216",
+				"port": 33357
+			},
+			"src": {
+				"id": "4ebe56795fc5da1c0dc5f7acd5760d5c8fd4d250",
+				"ip": "5.9.87.216",
+				"port": 33357
+			},
+			"buckets": [
+				83
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674127+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "5b0d1b8cb6f893426168300f69a82750d4be8729",
+				"ip": "193.35.57.185",
+				"port": 11656
+			},
+			"src": {
+				"id": "5b0d1b8cb6f893426168300f69a82750d4be8729",
+				"ip": "193.35.57.185",
+				"port": 11656
+			},
+			"buckets": [
+				228
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958611+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "890940193b592e7b53b882b62bf85d7a25190192",
+				"ip": "51.222.244.105",
+				"port": 26656
+			},
+			"src": {
+				"id": "890940193b592e7b53b882b62bf85d7a25190192",
+				"ip": "51.222.244.105",
+				"port": 26656
+			},
+			"buckets": [
+				48
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671172+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "de7a0953f9d5878604c077a54925167c120a97eb",
+				"ip": "141.95.65.115",
+				"port": 26656
+			},
+			"src": {
+				"id": "de7a0953f9d5878604c077a54925167c120a97eb",
+				"ip": "141.95.65.115",
+				"port": 26656
+			},
+			"buckets": [
+				218
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671223+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "c1c92e14d641a6368627da662b96ff77135e4754",
+				"ip": "185.182.193.20",
+				"port": 26656
+			},
+			"src": {
+				"id": "c1c92e14d641a6368627da662b96ff77135e4754",
+				"ip": "185.182.193.20",
+				"port": 26656
+			},
+			"buckets": [
+				88
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674125+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "5bc86308e2b3730ce611abf622c8be752780f934",
+				"ip": "5.199.172.53",
+				"port": 26656
+			},
+			"src": {
+				"id": "5bc86308e2b3730ce611abf622c8be752780f934",
+				"ip": "5.199.172.53",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674147+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "6ba9f87efe6beb23bb7af2204eac769767d8ec78",
+				"ip": "78.129.165.127",
+				"port": 23656
+			},
+			"src": {
+				"id": "6ba9f87efe6beb23bb7af2204eac769767d8ec78",
+				"ip": "78.129.165.127",
+				"port": 23656
+			},
+			"buckets": [
+				165
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671237+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "deefd5d3a4d497be6772295d10174f021d344ac5",
+				"ip": "57.128.75.161",
+				"port": 26656
+			},
+			"src": {
+				"id": "deefd5d3a4d497be6772295d10174f021d344ac5",
+				"ip": "57.128.75.161",
+				"port": 26656
+			},
+			"buckets": [
+				159
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674108+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "bb72dcd76b96214c4e647a1ebfe47c9e541d5325",
+				"ip": "185.182.186.202",
+				"port": 26656
+			},
+			"src": {
+				"id": "bb72dcd76b96214c4e647a1ebfe47c9e541d5325",
+				"ip": "185.182.186.202",
+				"port": 26656
+			},
+			"buckets": [
+				88
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.67413+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "8240e8a13594d40b6839f183795c551503309d3c",
+				"ip": "57.128.87.18",
+				"port": 26656
+			},
+			"src": {
+				"id": "8240e8a13594d40b6839f183795c551503309d3c",
+				"ip": "57.128.87.18",
+				"port": 26656
+			},
+			"buckets": [
+				159
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674121+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "c7dac72f630d2b3c3354ed664bcd6704a8f9e627",
+				"ip": "51.79.229.177",
+				"port": 26656
+			},
+			"src": {
+				"id": "c7dac72f630d2b3c3354ed664bcd6704a8f9e627",
+				"ip": "51.79.229.177",
+				"port": 26656
+			},
+			"buckets": [
+				46
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674139+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "2f05b07cde80c5b08ee0159658f7977c7765f966",
+				"ip": "148.113.17.55",
+				"port": 26756
+			},
+			"src": {
+				"id": "2f05b07cde80c5b08ee0159658f7977c7765f966",
+				"ip": "148.113.17.55",
+				"port": 26756
+			},
+			"buckets": [
+				173
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674856+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "b833d0cac06e9831550f3273de21792cec23211d",
+				"ip": "78.46.21.248",
+				"port": 26656
+			},
+			"src": {
+				"id": "b833d0cac06e9831550f3273de21792cec23211d",
+				"ip": "78.46.21.248",
+				"port": 26656
+			},
+			"buckets": [
+				244
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958646+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "994574dc373fc7552d5fb2616ca9d40654760a91",
+				"ip": "141.164.42.9",
+				"port": 16400
+			},
+			"src": {
+				"id": "994574dc373fc7552d5fb2616ca9d40654760a91",
+				"ip": "141.164.42.9",
+				"port": 16400
+			},
+			"buckets": [
+				74
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671256+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "624257ef1a8b6e2d39ac13ed3e3e16963fbb54ea",
+				"ip": "149.102.156.193",
+				"port": 26656
+			},
+			"src": {
+				"id": "624257ef1a8b6e2d39ac13ed3e3e16963fbb54ea",
+				"ip": "149.102.156.193",
+				"port": 26656
+			},
+			"buckets": [
+				121
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671261+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "24a869f01efa19104dbce61ae6697952a9e9a5d2",
+				"ip": "139.84.232.124",
+				"port": 26656
+			},
+			"src": {
+				"id": "24a869f01efa19104dbce61ae6697952a9e9a5d2",
+				"ip": "139.84.232.124",
+				"port": 26656
+			},
+			"buckets": [
+				247
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674116+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "c89507c926f41901784f54b26e1ccc49ac9ecfda",
+				"ip": "31.214.144.83",
+				"port": 20056
+			},
+			"src": {
+				"id": "c89507c926f41901784f54b26e1ccc49ac9ecfda",
+				"ip": "31.214.144.83",
+				"port": 20056
+			},
+			"buckets": [
+				80
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671226+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "629c36a551ee1a3c8bb3ecee6e00a9977a60e53e",
+				"ip": "65.108.46.248",
+				"port": 56656
+			},
+			"src": {
+				"id": "629c36a551ee1a3c8bb3ecee6e00a9977a60e53e",
+				"ip": "65.108.46.248",
+				"port": 56656
+			},
+			"buckets": [
+				62
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.67484+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "62b11589e64b4cef9f7202a2fd012937b1522745",
+				"ip": "65.21.69.251",
+				"port": 26656
+			},
+			"src": {
+				"id": "62b11589e64b4cef9f7202a2fd012937b1522745",
+				"ip": "65.21.69.251",
+				"port": 26656
+			},
+			"buckets": [
+				179
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675451+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "e979a4f3528a4fac1c1ab93af14d26b978eead8a",
+				"ip": "162.19.72.172",
+				"port": 26656
+			},
+			"src": {
+				"id": "e979a4f3528a4fac1c1ab93af14d26b978eead8a",
+				"ip": "162.19.72.172",
+				"port": 26656
+			},
+			"buckets": [
+				195
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675449+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "4727239dfe0173ef862f55c2fa26e9a6a057a572",
+				"ip": "80.190.129.50",
+				"port": 26656
+			},
+			"src": {
+				"id": "4727239dfe0173ef862f55c2fa26e9a6a057a572",
+				"ip": "80.190.129.50",
+				"port": 26656
+			},
+			"buckets": [
+				79
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958594+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "23b88ebcfb2177dbd2d8b2920c363a25e038e69a",
+				"ip": "89.58.61.213",
+				"port": 2000
+			},
+			"src": {
+				"id": "23b88ebcfb2177dbd2d8b2920c363a25e038e69a",
+				"ip": "89.58.61.213",
+				"port": 2000
+			},
+			"buckets": [
+				110
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.958619+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "87af580078c80c630625db2360b3dc19483d29cd",
+				"ip": "185.182.194.163",
+				"port": 26656
+			},
+			"src": {
+				"id": "87af580078c80c630625db2360b3dc19483d29cd",
+				"ip": "185.182.194.163",
+				"port": 26656
+			},
+			"buckets": [
+				88
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.673348+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "094e037734702dc0803a58a10b50fc3bb46c7e73",
+				"ip": "51.210.34.156",
+				"port": 26656
+			},
+			"src": {
+				"id": "094e037734702dc0803a58a10b50fc3bb46c7e73",
+				"ip": "51.210.34.156",
+				"port": 26656
+			},
+			"buckets": [
+				78
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674111+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "b3f473393a6469c0da65e4a7ebaa3ff3182df705",
+				"ip": "37.120.245.32",
+				"port": 26656
+			},
+			"src": {
+				"id": "b3f473393a6469c0da65e4a7ebaa3ff3182df705",
+				"ip": "37.120.245.32",
+				"port": 26656
+			},
+			"buckets": [
+				138
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674852+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "d0c530290267e1c539f27061c9446d5042eaf1ca",
+				"ip": "161.97.180.20",
+				"port": 26656
+			},
+			"src": {
+				"id": "d0c530290267e1c539f27061c9446d5042eaf1ca",
+				"ip": "161.97.180.20",
+				"port": 26656
+			},
+			"buckets": [
+				162
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674843+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "5001de72be39622c9dc34f2117eccc3f3fca8a7a",
+				"ip": "34.91.84.93",
+				"port": 26756
+			},
+			"src": {
+				"id": "5001de72be39622c9dc34f2117eccc3f3fca8a7a",
+				"ip": "34.91.84.93",
+				"port": 26756
+			},
+			"buckets": [
+				252
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675444+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "4b19506a0432de219ee2db883c53756c1b3cbdfb",
+				"ip": "88.217.142.187",
+				"port": 26656
+			},
+			"src": {
+				"id": "4b19506a0432de219ee2db883c53756c1b3cbdfb",
+				"ip": "88.217.142.187",
+				"port": 26656
+			},
+			"buckets": [
+				205
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671157+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "3c18baae029c2d39347ef77ac777fe6fd38bc1e6",
+				"ip": "176.9.48.38",
+				"port": 20056
+			},
+			"src": {
+				"id": "3c18baae029c2d39347ef77ac777fe6fd38bc1e6",
+				"ip": "176.9.48.38",
+				"port": 20056
+			},
+			"buckets": [
+				154
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674032+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "f5bce79feec9068154e7f50fe8db7a8191a58663",
+				"ip": "82.220.38.204",
+				"port": 10056
+			},
+			"src": {
+				"id": "f5bce79feec9068154e7f50fe8db7a8191a58663",
+				"ip": "82.220.38.204",
+				"port": 10056
+			},
+			"buckets": [
+				136
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674835+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "0a0da77a47cc1a58febe39c73b3bc96758455de6",
+				"ip": "142.165.207.45",
+				"port": 26656
+			},
+			"src": {
+				"id": "0a0da77a47cc1a58febe39c73b3bc96758455de6",
+				"ip": "142.165.207.45",
+				"port": 26656
+			},
+			"buckets": [
+				98
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674029+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "a41b4bc451b1b71d537aa1018226e08d7fa7e44e",
+				"ip": "5.255.77.44",
+				"port": 26656
+			},
+			"src": {
+				"id": "a41b4bc451b1b71d537aa1018226e08d7fa7e44e",
+				"ip": "5.255.77.44",
+				"port": 26656
+			},
+			"buckets": [
+				24
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674854+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "22ea694db139e744c46c74c9b5f22851266630af",
+				"ip": "51.159.80.121",
+				"port": 2090
+			},
+			"src": {
+				"id": "22ea694db139e744c46c74c9b5f22851266630af",
+				"ip": "51.159.80.121",
+				"port": 2090
+			},
+			"buckets": [
+				14
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674861+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "1b92a439555a19ee6edea85b184abb6873757dae",
+				"ip": "51.89.173.96",
+				"port": 43656
+			},
+			"src": {
+				"id": "1b92a439555a19ee6edea85b184abb6873757dae",
+				"ip": "51.89.173.96",
+				"port": 43656
+			},
+			"buckets": [
+				53
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674118+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "be5ea8954fa452ad464ae8a7067f01bf5a0da556",
+				"ip": "147.135.144.53",
+				"port": 26656
+			},
+			"src": {
+				"id": "be5ea8954fa452ad464ae8a7067f01bf5a0da556",
+				"ip": "147.135.144.53",
+				"port": 26656
+			},
+			"buckets": [
+				17
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674133+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "572cb08735d4572fe62b2fc8b9555c479d8e162f",
+				"ip": "65.108.137.217",
+				"port": 26656
+			},
+			"src": {
+				"id": "572cb08735d4572fe62b2fc8b9555c479d8e162f",
+				"ip": "65.108.137.217",
+				"port": 26656
+			},
+			"buckets": [
+				62
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674859+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "fef05ab5f892d8c85c13e08f49935f1b0077efd0",
+				"ip": "95.163.230.31",
+				"port": 26656
+			},
+			"src": {
+				"id": "fef05ab5f892d8c85c13e08f49935f1b0077efd0",
+				"ip": "95.163.230.31",
+				"port": 26656
+			},
+			"buckets": [
+				15
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.675473+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "f103c4809c8263b311463422195e6ad8526911d6",
+				"ip": "74.118.136.167",
+				"port": 26656
+			},
+			"src": {
+				"id": "f103c4809c8263b311463422195e6ad8526911d6",
+				"ip": "74.118.136.167",
+				"port": 26656
+			},
+			"buckets": [
+				146
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671228+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "3af3e3556515eb68bfe4ec5ad134eb9ec56b521d",
+				"ip": "51.81.166.95",
+				"port": 16400
+			},
+			"src": {
+				"id": "3af3e3556515eb68bfe4ec5ad134eb9ec56b521d",
+				"ip": "51.81.166.95",
+				"port": 16400
+			},
+			"buckets": [
+				240
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.671254+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		},
+		{
+			"addr": {
+				"id": "005b439eca9a27b736156c0081a863a40b3be517",
+				"ip": "178.23.126.86",
+				"port": 26656
+			},
+			"src": {
+				"id": "005b439eca9a27b736156c0081a863a40b3be517",
+				"ip": "178.23.126.86",
+				"port": 26656
+			},
+			"buckets": [
+				12
+			],
+			"attempts": 0,
+			"bucket_type": 1,
+			"last_attempt": "2023-10-30T11:34:53.674019+01:00",
+			"last_success": "0001-01-01T00:00:00Z",
+			"last_ban_time": "0001-01-01T00:00:00Z"
+		}
+	]
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/networks/issues/513

Note: two peers were not added. Created via:

```
$ celestia-appd addrbook /Users/rootulp/git/rootulp/celestia/networks/celestia/peers.txt /Users/rootulp/git/rootulp/celestia/networks/celestia/addrbook.json
Error adding b751ffe713e3e5d80e8f45c3bd5e640ee9a91cb9@10.129.127.95:26656: Cannot add non-routable address b751ffe713e3e5d80e8f45c3bd5e640ee9a91cb9@10.129.127.95:26656
Error parsing 6c41c4e37467272507e77fd74fd2e9e32e094d84@celestia.xprv.io:30001: error looking up host (celestia.xprv.io): lookup celestia.xprv.io: no such host
Converted /Users/rootulp/git/rootulp/celestia/networks/celestia/peers.txt into /Users/rootulp/git/rootulp/celestia/networks/celestia/addrbook.json
```

## Testing

Created a full consensus node (via [mainnet.sh](https://gist.github.com/rootulp/c62add29cf777a52b2fe3d9e84cd93a1)) with this addressbook and didn't encounter any errors but I don't see any logs indicating that it's communicating with the nodes in the addressbook because the genesis time is in the future and it's sleeping...


```
12:04PM INF Adding unconditional peer ids ids=[] module=p2p
12:04PM INF Add our address to book addr={"id":"f703381387acc941e863252e940d24725521173f","ip":"0.0.0.0","port":26656} book=/Users/rootulp/.celestia-app/config/addrbook.json module=p2p
12:04PM INF service start impl=Node msg={}
12:04PM INF Genesis time is in the future. Sleeping until then... genTime=2023-10-31T14:00:00Z
12:04PM INF Starting pprof server laddr=localhost:6060
```