### PR TITLE
ci: update validate-genesis trigger from master to main

### DIFF
--- a/.github/workflows/validate-genesis.yml
+++ b/.github/workflows/validate-genesis.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 jobs:
   no-change:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

The repo's default branch was renamed from `master` to `main`. This updates the only remaining hardcoded `master` reference in the codebase — the `push` trigger in `validate-genesis.yml` — so that workflow continues to run on pushes to the default branch.

No associated GitHub or Linear issue.

## Changes

- `.github/workflows/validate-genesis.yml`: `push.branches` `master` → `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)