### PR TITLE
Add CODEOWNERS assigning the protocol team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# The protocol team owns everything in this repository.
+* @celestiaorg/protocol


### PR DESCRIPTION
Adds a `CODEOWNERS` file assigning the `@celestiaorg/protocol` team as code owners for the entire repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)