### PR TITLE
ci: pin tj-actions/changed-files to a commit SHA

### DIFF
--- a/.github/workflows/validate-genesis.yml
+++ b/.github/workflows/validate-genesis.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - name: Check for Genesis file changes
         id: changed-genesis-files
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files: "**/*genesis.json"
 

--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed gentx files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files: "./celestia/*gentx*/*.json"
       - name: Set outputs


### PR DESCRIPTION
## Summary

Pins `tj-actions/changed-files` to the commit SHA for the `v46.0.5` release (`ed68ef82c095e0d48ec87eccea555d944a631a4c`) instead of the mutable `@v46.0.5` tag, with a trailing comment preserving the human-readable version.

`tj-actions` is a third-party action and was the target of a supply-chain compromise in March 2025, so referencing it by a movable tag is a genuine risk. Pinning to a full commit SHA makes the dependency immutable. (GitHub's own `actions/checkout` / `actions/setup-go` are treated as immutable and are not flagged by CodeQL.)

## Alerts addressed

Resolves the following `actions/unpinned-tag` (CodeQL, medium) code scanning alerts:

- `validate-genesis.yml:16` — alert #15
- `validate-gentx.yml:16` — alert #14

Closes https://github.com/celestiaorg/networks/security/code-scanning/14
Closes https://github.com/celestiaorg/networks/security/code-scanning/15

## Test plan

- CI workflows still parse and run on this PR (pure YAML config change).
- SHA verified against the `v46.0.5` tag via `gh api repos/tj-actions/changed-files/git/refs/tags/v46.0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)