### PR TITLE
docs: explain seeds/peers files and fix broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ This repository contains the configuration files for Celestia networks.
 
 Please refer to the [Celestia Docs](https://docs.celestia.org) for guides on running your own node. The configuration files `genesis.json` and `addrbook.json` are intended for use by Consensus nodes and should be placed in the node's home directory (by default `$HOME/.celestia-app/config`).
 
+## Seeds and peers
+
+Some networks include `seeds.txt` and/or `peers.txt` files. Each line is a node address in the form `nodeID@host:port` (for example `8084e73b70dbe7fba3602be586de45a516012e6f@144.76.112.238:26656`).
+
+A brand new node has no way to find the rest of the network on its own, so it needs at least one known address to bootstrap from. These files provide those starting points:
+
+- **Seeds** (`seeds.txt`) are nodes that exist purely for peer discovery. Your node connects to a seed, downloads a list of other addresses in the network, and then disconnects. Seeds do not maintain a persistent connection, so they are the lightweight way to discover peers when joining a network.
+- **Peers** (`peers.txt`) are nodes you connect to and stay connected to (configured as persistent peers). Unlike seeds, your node keeps these connections open to relay blocks and transactions.
+
+Node operators need these because a node cannot sync the chain or participate in consensus until it has connected to the network. Provide them via your node's config or command-line flags:
+
+- Add the contents of `seeds.txt` to the `seeds` field in `config.toml` (or pass `--p2p.seeds`).
+- Add the contents of `peers.txt` to the `persistent_peers` field in `config.toml` (or pass `--p2p.persistent_peers`).
+
+Multiple entries are comma-separated when placed in config or flags. See the [Celestia Docs](https://docs.celestia.org) for the exact steps for the node type you are running.
+
 ## Networks
 
 | Name     | Type    | Chain ID     | Configs                    |
@@ -14,4 +30,4 @@ Please refer to the [Celestia Docs](https://docs.celestia.org) for guides on run
 
 ## Software versions
 
-The celestia-app and celestia-node versions in use on each network are visible [in the Celestia Docs](https://docs.celestia.org/how-to-guides/participate).
+The celestia-app and celestia-node versions in use on each network are visible [in the Celestia Docs](https://docs.celestia.org/operate/networks/overview/).


### PR DESCRIPTION
## Overview

Two README improvements for node operators:

1. **New "Seeds and peers" section** explaining what the `seeds.txt` and `peers.txt` files in this repo are:
   - The `nodeID@host:port` line format, with an example.
   - Why a fresh node needs them (it can't find the network or sync without a bootstrap address).
   - The distinction between **seeds** (connect → fetch peer list → disconnect; lightweight discovery) and **persistent peers** (connections kept open to relay blocks/txs).
   - How to configure them (`seeds` / `persistent_peers` in `config.toml`, or `--p2p.seeds` / `--p2p.persistent_peers`), noting entries are comma-separated.

2. **Fixed broken link** in the "Software versions" section. The old `https://docs.celestia.org/how-to-guides/participate` URL 404s; updated it to the current networks overview page (`https://docs.celestia.org/operate/networks/overview/`), which has the same title and per-network version tables.

Closes: N/A (no associated GitHub or Linear issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)