### PR TITLE
chore: remove decommissioned mainnet seed-1 from celestia seeds

### DIFF
--- a/celestia/seeds.txt
+++ b/celestia/seeds.txt
@@ -1,4 +1,3 @@
-19b3ef846732c465cc32da3eaddb9c0fb41f57d2@consensus-full-seed-1.celestia-bootstrap.net:26656
 cf7ac8b19ff56a9d47c75551bd4864883d1e24b5@consensus-full-seed-2.celestia-bootstrap.net:26656
 acca7837e4eb5f9dc7f5a94ed1d82edda6931ff8@seed.celestia.pops.one:26656
 c5a23c66db975038c4eb131f65717059f597fe59@celestia-mainnet.stakingcabin.com:21656


### PR DESCRIPTION
consensus-full-seed-1.celestia-bootstrap.net is being retired (celestiaorg/infrastructure#548); drop it from the public seed list.

Ref https://github.com/celestiaorg/infrastructure/pull/548

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
