### PR TITLE
chore: remove non-functional seed-2 from celestia seeds.txt

### DIFF
--- a/celestia/seeds.txt
+++ b/celestia/seeds.txt
@@ -1,4 +1,3 @@
-cf7ac8b19ff56a9d47c75551bd4864883d1e24b5@consensus-full-seed-2.celestia-bootstrap.net:26656
 acca7837e4eb5f9dc7f5a94ed1d82edda6931ff8@seed.celestia.pops.one:26656
 c5a23c66db975038c4eb131f65717059f597fe59@celestia-mainnet.stakingcabin.com:21656
 9b1d22c3a78487d1a664a4b6a331fce527d14fb4@seed.celestia.mainnet.dteam.tech:27656


### PR DESCRIPTION
## Overview

Removes `cf7ac8b19ff56a9d47c75551bd4864883d1e24b5@consensus-full-seed-2.celestia-bootstrap.net:26656` from `celestia/seeds.txt`.

Follow-up to #562 (which removed seed-1); with this, both `celestia-bootstrap.net` seed entries are gone from the file.

Closes https://github.com/celestiaorg/networks/issues/563

## Investigation

seed-2 is not a functional seed node:

**1. It refuses all TCP connections.** The DNS record still resolves (`consensus-full-seed-2.celestia-bootstrap.net` → `62.210.39.110`, no AAAA) and the IP answers ICMP, but nothing is listening:

| Target | ICMP | tcp/26656 |
|---|---|---|
| `consensus-full-seed-1...` (62.210.93.163) — control | ✅ replies | ✅ **succeeded** |
| `consensus-full-seed-2...` (62.210.39.110) | ✅ replies | ❌ **connection refused** |

`Connection refused` (RST, not a timeout) was reproduced on 3 consecutive attempts, both by IP and by hostname. Ports 26657 and 22 are refused as well, i.e. the host serves nothing at all — this is not a firewall dropping only p2p traffic.

**2. No seed-2 host exists in infrastructure.** `celestiaorg/infrastructure` terraform defines only `terraform/environments/lunar/fr-par-1/seed-1/terragrunt.hcl`; there is no seed-2 environment. All 23 `seed-2` matches in that repo are either client-side `seeds = "..."` lists (other nodes dialing it) or the `"example"` array in `terraform/dns-registry.json` — never a host definition.

**3. It is absent from the node-fleet Grafana dashboard**, as noted in celestiaorg/infrastructure#548 (review).

Conclusion: celestiaorg no longer runs a seed-2; only the stale DNS record remains. Keeping it in `seeds.txt` makes every node operator waste dial attempts on a dead address.

## Follow-ups (not in this PR)

- `celestiaorg/celestia-app` `scripts/mainnet.sh` still lists seed-2, and lists seed-1 under a **different** node ID (`e6116822...`) than this repo used (`19b3ef84...`).
- Leftover `consensus-full-seed-2` DNS record, and the `ConsensusHeightMissing` / `ConsensusHeightStuck` alerts for `app="consensus-full-seed-2"` in `celestiaorg/alerts`.
- The newest infra app configs (`v9.0.6`) still carry seed-2 in their `seeds = "..."` lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
