### PR TITLE
chore: remove decommissioned celestia-bootstrap seed from mainnet seeds

### DIFF
--- a/celestia/seeds.txt
+++ b/celestia/seeds.txt
@@ -1,4 +1,3 @@
-cf7ac8b19ff56a9d47c75551bd4864883d1e24b5@consensus-full-seed-2.celestia-bootstrap.net:26656
 acca7837e4eb5f9dc7f5a94ed1d82edda6931ff8@seed.celestia.pops.one:26656
 c5a23c66db975038c4eb131f65717059f597fe59@celestia-mainnet.stakingcabin.com:21656
 9b1d22c3a78487d1a664a4b6a331fce527d14fb4@seed.celestia.mainnet.dteam.tech:27656


### PR DESCRIPTION
The Celestia-operated mainnet seed infrastructure behind `celestia-bootstrap.net` has been decommissioned: the last seed host was destroyed on 2026-09-07 and the `consensus-full-seed-1/2.celestia-bootstrap.net` DNS records were removed the same day (seed-2 was the old k8s-era node, gone far longer). The first entry in `celestia/seeds.txt` therefore no longer resolves.

Removes the dead entry; the remaining 14 community seeds are unaffected.